### PR TITLE
Adjusted max length of everyreq and quotereq

### DIFF
--- a/bot/src/commands/requestEveryone.ts
+++ b/bot/src/commands/requestEveryone.ts
@@ -17,6 +17,7 @@ export class EveryoneRequestCommand extends ChatInputCommand {
                 .setName(cd.options[0].name)
                 .setDescription(cd.options[0].description)
                 .setRequired(true)
+                .setMaxLength(256)
         })
 
     async executable(): Promise<void> {

--- a/bot/src/commands/requestQuote.ts
+++ b/bot/src/commands/requestQuote.ts
@@ -17,6 +17,7 @@ export class QuoteRequestChatCommnad extends ChatInputCommand {
                 .setName(cd.options[0].name)
                 .setDescription(cd.options[0].description)
                 .setRequired(true)
+                .setMaxLength(256)
         })
 
     async executable(): Promise<void> {


### PR DESCRIPTION
Fixes request messages for everyone and quote possibly being too long, resulting in an error.